### PR TITLE
[修正]post画像のコード修正・タブレット端末のレスポンシブデザイン微修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,3 +122,20 @@
     padding: 0.5rem;
   }
 }
+
+@media (max-width: 1024px) {
+  .header {
+    flex-direction: column;
+    align-items: center;
+  }
+  .nav-menu {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem;
+    margin: 0 auto;
+  }
+  .nav-link {
+    text-align: center;
+    padding: 0.5rem;
+  }
+}

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -11,6 +11,11 @@
     justify-content: space-between;
 }
 
+.users-view .card-text {
+    overflow-wrap: break-word;
+    white-space: normal;
+}
+
 @media (max-width: 768px) {
     .user-profile {
         flex-direction: column;

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -71,7 +71,7 @@
               <h4 class="mb-0 me-3">画像</h4>
               <div class="flex-grow-1 border-top border-2 border-white"></div>
             </div>
-            <%= attachment_image_tag(@post, :image, class: "img-fluid", style: "max-width: 100%; height: auto;") %>
+            <%= image_tag attachment_url(@post, :image, host: request.base_url), class: "img-fluid", style: "max-width: 100%; height: auto;" %>
           </div>
         <% end %>
 


### PR DESCRIPTION
下記修正しましたのでご確認お願いいたします。

【修正箇所】
●iphone・ipadのsafariからだと画像が表示されないバグに対応
・posts/show.html.erbの「画像」のコードを絶対パスが生成されるように修正
●ipad airから閲覧した場合のレスポンシブデザインを微修正
・application.scssでmax-width:1024pxの場合のデザインを追加指定
・users.scssでcard-textのはみ出しを防止